### PR TITLE
Add multiple product select logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ define("CODECANYON_API_KEY", "UNr.....");
 define("CODECANYON_SLUG_PLUGIN", "my-plugin");
 ```
 
+## Adding multiple products
+
+Add suffixes to the constants
+
+```
+define("FS__PLUGIN_ID_PRODUCT_1", "1234");
+define("FS__PLUGIN_PK_APIKEY_PRODUCT_1", "pk_abcde...");
+define("FS__PLUGIN_SK_APIKEY_PRODUCT_1", "sk_abcde...");
+define("FS__PLUGIN_PLAN_ID_PRODUCT_1", "5678");
+define("FS__PLUGIN_PRICING_ID_PRODUCT_1", "90123");
+define("CODECANYON_SLUG_PLUGIN_PRODUCT_1", "my-plugin");
+```
+
+Modify `get_constants_by_product` function to add more products if needed
+
+Edit the `render_shortcode` function to add your product names
+
 ## Adding the license migration form
 
 Create a new page with and with the following shortcode: `[ctf_form]`

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ define("FS__PLUGIN_PRICING_ID_PRODUCT_1", "90123");
 define("CODECANYON_SLUG_PLUGIN_PRODUCT_1", "my-plugin");
 ```
 
-Modify `get_constants_by_product` function to add more products if needed
+Modify `get_constants_by_product` function with your product slugs and add more products if needed
 
-Edit the `render_shortcode` function to add your product names
+Edit the `render_shortcode` function with your product slugs and names
 
 ## Adding the license migration form
 

--- a/ctf-init.php
+++ b/ctf-init.php
@@ -209,8 +209,8 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 				'form_license_label'   => __('Enter your license key from CodeCanyon', 'np-ctf'),
 				'form_product_label'   => __('Select a product', 'np-ctf'),
 				'form_products'   		 => array(
-					'product_1' => __('Dinery', 'np-ctf'),
-					'product_2' => __('Margin', 'np-ctf')
+					'dinery' => __('Dinery', 'np-ctf'),
+					'margin' => __('Margin', 'np-ctf')
 				),
 				'form_button_label'    => __('Convert License', 'np-ctf'),
 				'form_success_message' => __('Confirmation email was successfully sent with your new access credentials and license key!', 'np-ctf'),
@@ -345,7 +345,7 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 			);
 
 			switch ($product) {
-        case 'product_1':
+				case 'dinery':
 					return array_merge( $defaults, array(
 						'freemius_plugin_id'     		 => defined("FS__PLUGIN_ID_PRODUCT_1") ? constant("FS__PLUGIN_ID_PRODUCT_1") : '',
 						'freemius_plugin_pk_apikey'  => defined("FS__PLUGIN_PK_APIKEY_PRODUCT_1") ? constant("FS__PLUGIN_PK_APIKEY_PRODUCT_1") : '',
@@ -354,7 +354,7 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 						'freemius_plugin_pricing_id' => defined("FS__PLUGIN_PRICING_ID_PRODUCT_1") ? constant("FS__PLUGIN_PRICING_ID_PRODUCT_1") : '',
 						'codecanyon_slug_plugin' 		 => defined("CODECANYON_SLUG_PLUGIN_PRODUCT_1") ? constant("CODECANYON_SLUG_PLUGIN_PRODUCT_1") : '',
 					) );
-        case 'product_2':
+				case 'margin':
 					return array_merge( $defaults, array(
 						'freemius_plugin_id'     		 => defined("FS__PLUGIN_ID_PRODUCT_2") ? constant("FS__PLUGIN_ID_PRODUCT_2") : '',
 						'freemius_plugin_pk_apikey'  => defined("FS__PLUGIN_PK_APIKEY_PRODUCT_2") ? constant("FS__PLUGIN_PK_APIKEY_PRODUCT_2") : '',
@@ -413,6 +413,7 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 				return;
 
 			} // end if;
+
 
 			// Check if the purchase code matches the selected product
 			if ( strtolower($license->product) !== $data['product'] ) {

--- a/ctf-init.php
+++ b/ctf-init.php
@@ -38,6 +38,8 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 		 */
 		public $version = '0.0.1';
 
+		public $debug = false;
+
 		/**
 		 * WP_Error messages
 		 *
@@ -205,6 +207,11 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 				'id'                   => '1',
 				'form_email_label'     => __('Enter your email address', 'np-ctf'),
 				'form_license_label'   => __('Enter your license key from CodeCanyon', 'np-ctf'),
+				'form_product_label'   => __('Select a product', 'np-ctf'),
+				'form_products'   		 => array(
+					'product_1' => __('Dinery', 'np-ctf'),
+					'product_2' => __('Margin', 'np-ctf')
+				),
 				'form_button_label'    => __('Convert License', 'np-ctf'),
 				'form_success_message' => __('Confirmation email was successfully sent with your new access credentials and license key!', 'np-ctf'),
 			), $atts, 'ctf_form');
@@ -291,7 +298,7 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 		 */
 		public function is_debug_mode() {
 
-			return isset($_GET['debug']) && $_GET['debug'] === 'SECRET!!!!';
+			return $this->debug;
 
 		} // end is_debug_mode;
 
@@ -322,28 +329,45 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 		 * Get ctf constants defined in wp-config.php
 		 *
 		 * @since 0.0.1
+		 * 
+		 * @param string $product Product.
 		 *
 		 * @return array
 		 */
-		public function get_constants_by_id() {
+		public function get_constants_by_product($product) {
 
-			return array(
+			$defaults = array(
 				'freemius_dev_pk_apikey'     => defined("FS__DEV_PK_APIKEY") ? constant("FS__DEV_PK_APIKEY") : '',
 				'freemius_dev_sk_apikey'     => defined("FS__DEV_SK_APIKEY") ? constant("FS__DEV_SK_APIKEY") : '',
 				'freemius_dev_id'            => defined("FS__DEV_ID") ? constant("FS__DEV_ID") : '',
-
-				'freemius_plugin_pk_apikey'  => defined("FS__PLUGIN_PK_APIKEY") ? constant("FS__PLUGIN_PK_APIKEY") : '',
-				'freemius_plugin_sk_apikey'  => defined("FS__PLUGIN_SK_APIKEY") ? constant("FS__PLUGIN_SK_APIKEY") : '',
-				'freemius_plugin_id'         => defined("FS__PLUGIN_ID") ? constant("FS__PLUGIN_ID") : '',
-				'freemius_plugin_plan_id'    => defined("FS__PLUGIN_PLAN_ID") ? constant("FS__PLUGIN_PLAN_ID") : '',
-				'freemius_plugin_pricing_id' => defined("FS__PLUGIN_PRICING_ID") ? constant("FS__PLUGIN_PRICING_ID") : '',
 				'freemius_plugin_expires_at' => defined("FS__PLUGIN_EXPIRES_AT") ? constant("FS__PLUGIN_EXPIRES_AT") : '',
-
 				'codecanyon_api_key'         => defined("CODECANYON_API_KEY") ? constant("CODECANYON_API_KEY") : '',
-				'codecanyon_slug_plugin'     => defined("CODECANYON_SLUG_PLUGIN") ? constant("CODECANYON_SLUG_PLUGIN") : '',
 			);
 
-		} // end get_constants_by_id;
+			switch ($product) {
+        case 'product_1':
+					return array_merge( $defaults, array(
+						'freemius_plugin_id'     		 => defined("FS__PLUGIN_ID_PRODUCT_1") ? constant("FS__PLUGIN_ID_PRODUCT_1") : '',
+						'freemius_plugin_pk_apikey'  => defined("FS__PLUGIN_PK_APIKEY_PRODUCT_1") ? constant("FS__PLUGIN_PK_APIKEY_PRODUCT_1") : '',
+						'freemius_plugin_sk_apikey'  => defined("FS__PLUGIN_SK_APIKEY_PRODUCT_1") ? constant("FS__PLUGIN_SK_APIKEY_PRODUCT_1") : '',
+						'freemius_plugin_plan_id'  	 => defined("FS__PLUGIN_PLAN_ID_PRODUCT_1") ? constant("FS__PLUGIN_PLAN_ID_PRODUCT_1") : '',
+						'freemius_plugin_pricing_id' => defined("FS__PLUGIN_PRICING_ID_PRODUCT_1") ? constant("FS__PLUGIN_PRICING_ID_PRODUCT_1") : '',
+						'codecanyon_slug_plugin' 		 => defined("CODECANYON_SLUG_PLUGIN_PRODUCT_1") ? constant("CODECANYON_SLUG_PLUGIN_PRODUCT_1") : '',
+					) );
+        case 'product_2':
+					return array_merge( $defaults, array(
+						'freemius_plugin_id'     		 => defined("FS__PLUGIN_ID_PRODUCT_2") ? constant("FS__PLUGIN_ID_PRODUCT_2") : '',
+						'freemius_plugin_pk_apikey'  => defined("FS__PLUGIN_PK_APIKEY_PRODUCT_2") ? constant("FS__PLUGIN_PK_APIKEY_PRODUCT_2") : '',
+						'freemius_plugin_sk_apikey'  => defined("FS__PLUGIN_SK_APIKEY_PRODUCT_2") ? constant("FS__PLUGIN_SK_APIKEY_PRODUCT_2") : '',
+						'freemius_plugin_plan_id'  	 => defined("FS__PLUGIN_PLAN_ID_PRODUCT_2") ? constant("FS__PLUGIN_PLAN_ID_PRODUCT_2") : '',
+						'freemius_plugin_pricing_id' => defined("FS__PLUGIN_PRICING_ID_PRODUCT_2") ? constant("FS__PLUGIN_PRICING_ID_PRODUCT_2") : '',
+						'codecanyon_slug_plugin' 		 => defined("CODECANYON_SLUG_PLUGIN_PRODUCT_2") ? constant("CODECANYON_SLUG_PLUGIN_PRODUCT_2") : '',
+					) );
+        default:
+          return $defaults; // or throw an error
+    	}
+
+		} // end get_constants_by_product;
 
 		/**
 		 * Handle of form submit
@@ -365,9 +389,10 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 			$data = array(
 				'license_key' => $_POST['license_key'],
 				'email'       => $_POST['email'],
+				'product'     => $_POST['product'],
 			);
 
-			$data = array_merge($data, $this->get_constants_by_id());
+			$data = array_merge($data, $this->get_constants_by_product($data['product']));
 
 			if (!$this->validation($data)) {
 				return;
@@ -379,7 +404,6 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 
 			if ($this->is_debug_mode()) {
 
-
 			} // end if;
 
 			if (!$license || $license->success == false) {
@@ -389,6 +413,13 @@ if (!class_exists('Codecanyon_To_Freemius')) :
 				return;
 
 			} // end if;
+
+			// Check if the purchase code matches the selected product
+			if ( strtolower($license->product) !== $data['product'] ) {
+				$this->messages->add('invalid-product', __('The product does not match your purchase code.', 'np-ctf'));
+				CTF_Logger::add('ctf_log_error', implode('<br>', $this->messages->get_error_messages()));
+				return;
+			}
 
 			$existing_user = $ctf_api->verify_freemius_exists_user($data['email']);
 

--- a/inc/ctf-api.php
+++ b/inc/ctf-api.php
@@ -238,6 +238,7 @@ class CTF_Api {
 			return (object) array(
 				'success'       => isset($output->buyer),
 				'golden_ticket' => isset($output->buyer),
+				'product'				=> isset($output->item->wordpress_theme_metadata->theme_name) ? $output->item->wordpress_theme_metadata->theme_name : '',
 				'purchase'      => (object) array(
 					'refunded' => false,
 				)

--- a/views/main.php
+++ b/views/main.php
@@ -26,6 +26,18 @@
   </p>
 
   <p>
+    <label for="np-ctf-panel-product">
+		<?php echo $atts['form_product_label']; ?>:
+      <select id="np-ctf-panel-product" class="form-control form-control-lg" name="product" required>
+        <option value=""><?php echo $atts['form_product_label']; ?></option>
+        <?php foreach ( $atts['form_products'] as $slug => $product ) : ?>
+          <option value="<?php echo $slug; ?>"><?php echo $product; ?></option>
+        <?php endforeach; ?>
+      </select>
+    </label>
+  </p>
+
+  <p>
     <button class="button button-primary btn btn-primary" type="submit">
 		<?php echo $atts['form_button_label']; ?>
     </button>


### PR DESCRIPTION
Users can select a product using a select dropdown.

## How to add multiple products

1. Add suffixes to the constants

```
define("FS__PLUGIN_ID_PRODUCT_1", "1234");
define("FS__PLUGIN_PK_APIKEY_PRODUCT_1", "pk_abcde...");
define("FS__PLUGIN_SK_APIKEY_PRODUCT_1", "sk_abcde...");
define("FS__PLUGIN_PLAN_ID_PRODUCT_1", "5678");
define("FS__PLUGIN_PRICING_ID_PRODUCT_1", "90123");
define("CODECANYON_SLUG_PLUGIN_PRODUCT_1", "my-plugin");
```

2. Modify the `get_constants_by_product` function with your product slugs and add more products if needed

3. Edit the `render_shortcode` function with your product slugs and names